### PR TITLE
Improve Add-M365PSProfile to add to an existing profile

### DIFF
--- a/M365PSProfile.psm1
+++ b/M365PSProfile.psm1
@@ -81,7 +81,7 @@ Function Add-M365PSProfile {
 		Add PowerShell Profile with M365PSProfile setup
 
 		.DESCRIPTION
-		Add PowerShell Profile with M365PSProfile setup (if no PowerShell Profile exists).
+		Add PowerShell Profile with M365PSProfile setup.
 
 		Needs to be executed separately for PowerShell v5 and v7.
 
@@ -91,18 +91,30 @@ Function Add-M365PSProfile {
 		.LINK
 		https://github.com/fabrisodotps1/M365PSProfile
 	#>
-	
-	If (-not(Test-Path -Path $Profile)) {
-		Write-Host "No PowerShell Profile exists. A new Profile with the M365PSProfile setup is created."
+	[CmdletBinding(SupportsShouldProcess, ConfirmImpact = 'Medium')]
+    	param()
 
-$ProfileContent = @"
+	$ProfileContent = @"
+
 #M365PSProfile: Install or updates the default Modules (what we think every M365 Admin needs) in the CurrentUser Scope
 Import-Module -Name M365PSProfile
 Install-M365Module
 "@
+
+	If (-not(Test-Path -Path $Profile)) {
+		Write-Host "No PowerShell Profile exists. A new Profile with the M365PSProfile setup is created."
 		$ProfileContent | Out-File -FilePath $Profile -Encoding utf8 -Force
 	} else {
-		Write-Host "PowerShell Profile already exists. Add the commands for the M365PSProfile setup to the Profile." -ForegroundColor Yellow
+		Write-Host "PowerShell Profile already exists. You could manually add the following code to your PowerShell profile: `r`n" -ForegroundColor Yellow
+		Write-Host $ProfileContent -ForegroundColor Magenta
+		Write-Host "`r`nThis command can also add the code to the end of your profile file ($($Profile))."
+		
+		if ($PSCmdlet.ShouldContinue($Path, "Add ""Install-M365Module"" to the PowerShell Profile file $($Profile)")) {
+			Write-Host "Adding to profile..."
+			Add-Content -Path $Profile -Value $ProfileContent
+		} else {
+			Write-Host "Okay, not changing your profile."
+		}
 	}
 }
 

--- a/M365PSProfile.psm1
+++ b/M365PSProfile.psm1
@@ -111,7 +111,7 @@ Install-M365Module
 		
 		if ($PSCmdlet.ShouldContinue($Path, "Add ""Install-M365Module"" to the PowerShell Profile file $($Profile)")) {
 			Write-Host "Adding to profile..."
-			Add-Content -Path $Profile -Value $ProfileContent
+			Add-Content -Path $Profile -Value $ProfileContent -Encoding utf8
 		} else {
 			Write-Host "Okay, not changing your profile."
 		}


### PR DESCRIPTION
I improved the `Add-M365PSProfile` function, so it can add the commands to an existing PowerShell profile. It will only do so, if the user confirms (using ShouldContinue to ask for confirmation).
The function will also display the code, so the user can better examine what will happen OR they could use that info to manually add the code to their profile.

The prefix new line for the profile code is on purpose. It helps, if the user profile is currently not ending with a new line.